### PR TITLE
Use the import api for new dashboards

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -70,7 +70,7 @@ func (c *Client) NewDashboard(dashboard Dashboard) (*DashboardSaveResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	req, err := c.newRequest("POST", "/api/dashboards/db", nil, bytes.NewBuffer(data))
+	req, err := c.newRequest("POST", "/api/dashboards/import", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Based on recommendations from
[grafana](https://github.com/grafana/grafana/issues/7592#issuecomment-280407404)
we should prefer the import api to the db api when creating new
dashboards. It has the same format and response so we shouldn't need any
other changes